### PR TITLE
Update emotion support (MUI latest version) and add support for Node with ESM

### DIFF
--- a/examples/support-yarn2-pnp/package.json
+++ b/examples/support-yarn2-pnp/package.json
@@ -23,8 +23,7 @@
     "lz-string": "^1.4.4",
     "pnp-webpack-plugin": "^1.6.4",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "urlsafe-base64": "^1.0.0"
+    "react-dom": "^16.13.1"
   },
   "installConfig": {
     "pnp": true

--- a/packages/core/lib/webpack/antd.js
+++ b/packages/core/lib/webpack/antd.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import LZString from 'lz-string';
-import URLSafeBase64 from 'urlsafe-base64';
 import App from '__REACT_SSR_APP__';
 import Page from '__REACT_SSR_PAGE__';
 
 const getProps = () => {
   const compressedProps = document.getElementById('react-ssr-script').dataset.props;
-  const decoded = URLSafeBase64.decode(compressedProps);
-  const decompressed = LZString.decompressFromUint8Array(decoded);
+  const decompressed = LZString.decompressFromBase64(compressedProps);
   return JSON.parse(decompressed);
 }
 

--- a/packages/core/lib/webpack/default.js
+++ b/packages/core/lib/webpack/default.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import LZString from 'lz-string';
-import URLSafeBase64 from 'urlsafe-base64';
 import App from '__REACT_SSR_APP__';
 import Page from '__REACT_SSR_PAGE__';
 
 const getProps = () => {
   const compressedProps = document.getElementById('react-ssr-script').dataset.props;
-  const decoded = URLSafeBase64.decode(compressedProps);
-  const decompressed = LZString.decompressFromUint8Array(decoded);
+  const decompressed = LZString.decompressFromBase64(compressedProps);
   return JSON.parse(decompressed);
 }
 

--- a/packages/core/lib/webpack/emotion.js
+++ b/packages/core/lib/webpack/emotion.js
@@ -3,14 +3,12 @@ import ReactDOM from 'react-dom';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import LZString from 'lz-string';
-import URLSafeBase64 from 'urlsafe-base64';
 import App from '__REACT_SSR_APP__';
 import Page from '__REACT_SSR_PAGE__';
 
 const getProps = () => {
   const compressedProps = document.getElementById('react-ssr-script').dataset.props;
-  const decoded = URLSafeBase64.decode(compressedProps);
-  const decompressed = LZString.decompressFromUint8Array(decoded);
+  const decompressed = LZString.decompressFromBase64(compressedProps);
   return JSON.parse(decompressed);
 }
 

--- a/packages/core/lib/webpack/emotion.js
+++ b/packages/core/lib/webpack/emotion.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { CacheProvider } from '@emotion/core';
+import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import LZString from 'lz-string';
 import URLSafeBase64 from 'urlsafe-base64';
@@ -14,7 +14,7 @@ const getProps = () => {
   return JSON.parse(decompressed);
 }
 
-const cache = createCache();
+const cache = createCache({ key: "react-ssr" });
 
 ReactDOM.render(
   <CacheProvider value={cache}>

--- a/packages/core/lib/webpack/material-ui.js
+++ b/packages/core/lib/webpack/material-ui.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import LZString from 'lz-string';
-import URLSafeBase64 from 'urlsafe-base64';
 import App from '__REACT_SSR_APP__';
 import Page from '__REACT_SSR_PAGE__';
 
 const getProps = () => {
   const compressedProps = document.getElementById('react-ssr-script').dataset.props;
-  const decoded = URLSafeBase64.decode(compressedProps);
-  const decompressed = LZString.decompressFromUint8Array(decoded);
+  const decompressed = LZString.decompressFromBase64(compressedProps);
   return JSON.parse(decompressed);
 }
 

--- a/packages/core/lib/webpack/styled-components.js
+++ b/packages/core/lib/webpack/styled-components.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import LZString from 'lz-string';
-import URLSafeBase64 from 'urlsafe-base64';
 import App from '__REACT_SSR_APP__';
 import Page from '__REACT_SSR_PAGE__';
 
 const getProps = () => {
   const compressedProps = document.getElementById('react-ssr-script').dataset.props;
-  const decoded = URLSafeBase64.decode(compressedProps);
-  const decompressed = LZString.decompressFromUint8Array(decoded);
+  const decompressed = LZString.decompressFromBase64(compressedProps);
   return JSON.parse(decompressed);
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,6 @@
     "slash": "3.0.0",
     "terser-webpack-plugin": "5.3.6",
     "unionfs": "4.4.0",
-    "urlsafe-base64": "1.0.0",
     "webpack": "5.74.0",
     "webpack-dev-server": "4.10.1",
     "webpack-merge": "5.8.0"
@@ -81,7 +80,6 @@
     "@types/react": "^18.0.18",
     "@types/react-dom": "^18.0.6",
     "@types/recursive-readdir": "^2.2.1",
-    "@types/urlsafe-base64": "^1.0.28",
     "@types/webpack": "^5.28.0",
     "cross-env": "^7.0.3",
     "express": "^4.18.1",

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -38,8 +38,11 @@ const getSsrConfig = (): Config => {
     staticViews: [],
   };
   const ssrConfigPath = path.join(cwd, 'ssr.config.js');
+  const ssrConfigCjsPath = path.join(cwd, 'ssr.config.cjs');
   if (existsSync(ssrConfigPath)) {
     return Object.assign(defaultConfig, require(ssrConfigPath));
+  } else if (existsSync(ssrConfigCjsPath)) {
+    return Object.assign(defaultConfig, require(ssrConfigCjsPath));
   } else {
     return defaultConfig;
   }

--- a/packages/core/src/optimize/webpack.config.ts
+++ b/packages/core/src/optimize/webpack.config.ts
@@ -49,6 +49,7 @@ const prodConfig: webpack.Configuration = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env.REACT_SSR_ENV': JSON.stringify('production'),
     }),
   ],
 };

--- a/packages/core/src/render/index.tsx
+++ b/packages/core/src/render/index.tsx
@@ -3,7 +3,6 @@ import path from 'path';
 import React from 'react';
 import slash from 'slash';
 import LZString from 'lz-string';
-import URLSafeBase64 from 'urlsafe-base64';
 import App from '../components/App';
 import Document from '../components/Document';
 import {
@@ -96,8 +95,7 @@ const getRenderToStringMethod = async () => {
 
 const compressProps = (props: any) => {
   const packed = JSON.stringify(props);
-  const compressed = Buffer.from(LZString.compressToUint8Array(packed));
-  return URLSafeBase64.encode(compressed);
+  return LZString.compressToBase64(packed);
 }
 
 export default async function render(file: string, props: any): Promise<string> {

--- a/packages/core/src/render/stringify/emotion.tsx
+++ b/packages/core/src/render/stringify/emotion.tsx
@@ -8,12 +8,12 @@ import {
 
 const Head = require('./head');
 
-const { CacheProvider } = require('@emotion/core');
+const { CacheProvider } = require('@emotion/react');
 const emotionCache = require('@emotion/cache');
-const emotionServer = require('create-emotion-server');
+const emotionServer = require('@emotion/server/create-instance');
 const createCache = emotionCache.default || emotionCache;
 const createEmotionServer = emotionServer.default || emotionServer;
-const cache = createCache();
+const cache = createCache({ key: "react-ssr" });
 const { extractCritical } = createEmotionServer(cache);
 
 export default (app: React.ReactElement, pageId: string, props: string) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,6 @@ importers:
       '@types/react': ^18.0.18
       '@types/react-dom': ^18.0.6
       '@types/recursive-readdir': ^2.2.1
-      '@types/urlsafe-base64': ^1.0.28
       '@types/webpack': ^5.28.0
       babel-loader: 8.2.5
       babel-plugin-css-modules-transform: 1.6.2
@@ -61,7 +60,6 @@ importers:
       terser-webpack-plugin: 5.3.6
       typescript: ^4.8.2
       unionfs: 4.4.0
-      urlsafe-base64: 1.0.0
       webpack: 5.74.0
       webpack-dev-server: 4.10.1
       webpack-merge: 5.8.0
@@ -97,7 +95,6 @@ importers:
       slash: 3.0.0
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       unionfs: 4.4.0
-      urlsafe-base64: 1.0.0
       webpack: 5.74.0
       webpack-dev-server: 4.10.1_webpack@5.74.0
       webpack-merge: 5.8.0
@@ -114,7 +111,6 @@ importers:
       '@types/react': 18.0.18
       '@types/react-dom': 18.0.6
       '@types/recursive-readdir': 2.2.1
-      '@types/urlsafe-base64': 1.0.28
       '@types/webpack': 5.28.0
       cross-env: 7.0.3
       express: 4.18.1
@@ -1672,12 +1668,6 @@ packages:
     dependencies:
       '@types/node': 18.7.14
     dev: false
-
-  /@types/urlsafe-base64/1.0.28:
-    resolution: {integrity: sha512-TG5dKbqx75FUTXfiARIPvLvMCImVYJbKM+Fvy9HgpxkunHnMHNAn78xpvcZxIbPITyRzf0b2Gl8fnd1Ja3p1eQ==}
-    dependencies:
-      '@types/node': 18.7.14
-    dev: true
 
   /@types/webpack/5.28.0:
     resolution: {integrity: sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==}
@@ -4781,10 +4771,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
-
-  /urlsafe-base64/1.0.0:
-    resolution: {integrity: sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA==}
-    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}


### PR DESCRIPTION
- Updates Emotion imports to use `@emotion/react` instead of `@emotion/core` [[reference](https://github.com/emotion-js/emotion/blob/1135f8e9d97ea711eb483368313afdfe7b176845/docs/emotion-11.mdx?plain=1#L20)]
- Add `key` to Emotion's `createCache` method, which is now required [[reference](https://github.com/emotion-js/emotion/blob/1135f8e9d97ea711eb483368313afdfe7b176845/packages/cache/src/index.js#L47-L54)]
- Add support for loading config from `ssr.config.cjs`, as Node.js with ESM (package.json's `"type": "module"` doesn't allow require of .js files [[reference](https://nodejs.org/api/modules.html#enabling)]
- Remove the dependency of `urlsafe-base64`, as it relies on `Buffer` API, which is not available in the browser